### PR TITLE
Turn off token requirement on creating a user.

### DIFF
--- a/api/users/routes/createUser.js
+++ b/api/users/routes/createUser.js
@@ -20,13 +20,14 @@ module.exports = {
   method: 'POST',
   path: '/api/users',
   config: {
+    auth: false,
     // Before the route handler runs, verify that
     // the user is unique and assign the result to 'user'
     pre: [
       { method: verifyUniqueUser, assign: 'user' }
     ],
     handler: (req, res) => {
-      
+
       let user = new User();
       user.email = req.payload.email;
       user.username = req.payload.username;
@@ -44,11 +45,11 @@ module.exports = {
           res({ id_token: createToken(user) }).code(201);
         });
       });
-      
+
     },
     // Validate the payload against the Joi schema
     validate: {
       payload: createUserSchema
     }
-  }  
+  }
 }


### PR DESCRIPTION
Doesn’t really make sense to protect the create user endpoint :)

Thanks for creating this great tutorial!
