### PR TITLE
Remove unnecessary assign in pre handler

### DIFF
--- a/api/users/routes/createUser.js
+++ b/api/users/routes/createUser.js
@@ -21,10 +21,9 @@ module.exports = {
   path: '/api/users',
   config: {
     auth: false,
-    // Before the route handler runs, verify that
-    // the user is unique and assign the result to 'user'
+    // Before the route handler runs, verify that the user is unique
     pre: [
-      { method: verifyUniqueUser, assign: 'user' }
+      { method: verifyUniqueUser }
     ],
     handler: (req, res) => {
 


### PR DESCRIPTION
The article should also be updated. The following line was confusing since it isn't true:

> This property is available in the route handler and is what we use to create the token.

Later in the article `pre` is used as mentioned for the `/api/users/authenticate` route but _not_ at this point in the article.
