### PR TITLE
Replaced bcrypt with bcryptjs

### DIFF
--- a/api/users/routes/checkUser.js
+++ b/api/users/routes/checkUser.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const bcrypt = require('bcrypt');
+const bcrypt = require('bcryptjs');
 const Boom = require('boom');
 const User = require('../model/User');
 const checkUserSchema = require('../schemas/checkUser');

--- a/api/users/routes/createUser.js
+++ b/api/users/routes/createUser.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const bcrypt = require('bcrypt');
+const bcrypt = require('bcryptjs');
 const Boom = require('boom');
 const User = require('../model/User');
 const createUserSchema = require('../schemas/createUser');

--- a/api/users/util/userFunctions.js
+++ b/api/users/util/userFunctions.js
@@ -2,14 +2,14 @@
 
 const Boom = require('boom');
 const User = require('../model/User');
-const bcrypt = require('bcrypt');
+const bcrypt = require('bcryptjs');
 
 function verifyUniqueUser(req, res) {
   // Find an entry from the database that
   // matches either the email or username
-  User.findOne({ 
-    $or: [ 
-      { email: req.payload.email }, 
+  User.findOne({
+    $or: [
+      { email: req.payload.email },
       { username: req.payload.username }
     ]
   }, (err, user) => {
@@ -32,13 +32,13 @@ function verifyUniqueUser(req, res) {
 }
 
 function verifyCredentials(req, res) {
-  
+
   const password = req.payload.password;
-  
+
   // Find an entry from the database that
   // matches either the email or username
-  User.findOne({ 
-    $or: [ 
+  User.findOne({
+    $or: [
       { email: req.payload.email },
       { username: req.payload.username }
     ]

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "author": "Auth0",
   "license": "MIT",
   "dependencies": {
-    "bcrypt": "^0.8.5",
+    "bcryptjs": "^2.3.0",
     "boom": "^3.1.2",
     "glob": "^7.0.0",
     "hapi": "^13.0.0",


### PR DESCRIPTION
As mentioned in #6, bcryptjs is a lighter JS only drop in replacement for bcrypt. Performance takes a hit, but as this is a tutorial I think ease of use across all platforms is a better goal.
